### PR TITLE
display row replies and last activity correctly

### DIFF
--- a/packages/backend/src/routes/forum/posts/get_post_list.rs
+++ b/packages/backend/src/routes/forum/posts/get_post_list.rs
@@ -57,6 +57,7 @@ pub struct GetPostListResponseBodyInner {
     view_count: i64,
     #[ts(type = "number")]
     vote_count: i64,
+    #[ts(type = "number")]
     reply_count: i64,
     #[serde(with = "time::serde::rfc3339")]
     #[ts(type = "string")]

--- a/packages/frontend/src/pages/forum/index.tsx
+++ b/packages/frontend/src/pages/forum/index.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
 import ky from 'ky-universal'
 import type { GetServerSidePropsResult } from 'next'
 import Head from 'next/head'
@@ -46,6 +47,8 @@ export async function getServerSideProps (): Promise<GetServerSidePropsResult<{ 
 function Forum ({ response }: { response: GetPostListResponseBody }): JSX.Element {
   const [page, setPage] = useState(1)
   const [announcements, setAnnouncements] = useState(response)
+
+  dayjs.extend(relativeTime)
 
   function goToPreviousPage (): void {
     const nextPage = page - 1
@@ -120,9 +123,9 @@ function Forum ({ response }: { response: GetPostListResponseBody }): JSX.Elemen
                           </p>
                         </div>
                       </td>
-                      <td>10</td>
+                      <td>{a.reply_count}</td>
                       <td>{a.view_count}</td>
-                      <td>1h</td>
+                      <td>{dayjs(a.last_active_timestamp).fromNow()}</td>
                     </tr>
                   )
                 })


### PR DESCRIPTION
Fixes #9 

Some concerns about react cannot display `bigint` can be tracked at facebook/react#24580, facebook/react#24716 and facebook/react#20492